### PR TITLE
Add windowsHide: true to the different spawn calls

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -32,7 +32,7 @@ function start() {
   const port = findPort();
   const p = spawn(process.execPath, [require.resolve('./worker'), port], {
     stdio: 'inherit',
-    windowsHide: true
+    windowsHide: true,
   });
   p.unref();
   process.on('exit', () => {
@@ -46,11 +46,13 @@ function start() {
 }
 
 function findPort() {
-  const findPortResult = spawnSync(process.execPath, [
-    require.resolve('./find-port'),
-  ], {
-    windowsHide: true
-  });
+  const findPortResult = spawnSync(
+    process.execPath,
+    [require.resolve('./find-port')],
+    {
+      windowsHide: true,
+    }
+  );
   if (findPortResult.error) {
     if (typeof findPortResult.error === 'string') {
       throw new Error(findPortResult.error);
@@ -166,3 +168,4 @@ createClient.FUNCTION_PRIORITY = FUNCTION_PRIORITY;
 createClient.configuration = configuration;
 
 module.exports = createClient;
+

--- a/lib/index.js
+++ b/lib/index.js
@@ -32,6 +32,7 @@ function start() {
   const port = findPort();
   const p = spawn(process.execPath, [require.resolve('./worker'), port], {
     stdio: 'inherit',
+    windowsHide: true
   });
   p.unref();
   process.on('exit', () => {
@@ -47,7 +48,9 @@ function start() {
 function findPort() {
   const findPortResult = spawnSync(process.execPath, [
     require.resolve('./find-port'),
-  ]);
+  ], {
+    windowsHide: true
+  });
   if (findPortResult.error) {
     if (typeof findPortResult.error === 'string') {
       throw new Error(findPortResult.error);
@@ -87,15 +90,15 @@ function waitForAlive(port) {
 }
 
 function nativeNC(port, input) {
-  return spawnSync('nc', [host, port], {input: input});
+  return spawnSync('nc', [host, port], {input: input, windowsHide: true});
 }
 
 function nodeNC(port, input) {
   const src = nodeNetCatSrc(port, input);
   if (src.length < 1000) {
-    return spawnSync(process.execPath, ['-e', src]);
+    return spawnSync(process.execPath, ['-e', src], {windowsHide: true});
   } else {
-    return spawnSync(process.execPath, [], {input: src});
+    return spawnSync(process.execPath, [], {input: src, windowsHide: true});
   }
 }
 


### PR DESCRIPTION
This is to avoid creating CMD windows in Windows when this library is used.