### PR TITLE
Fix macOS firewall popup appearing on init

### DIFF
--- a/lib/find-port.js
+++ b/lib/find-port.js
@@ -2,7 +2,7 @@
 
 const getPort = require('get-port');
 
-getPort()
+getPort({ host: process.argv[2] })
   .then(port => process.stdout.write('' + port))
   .catch(err =>
     setTimeout(() => {

--- a/lib/index.js
+++ b/lib/index.js
@@ -29,7 +29,7 @@ function start() {
         'you can `npm install sync-request@2.2.0`, which was the last version to support older versions of node.'
     );
   }
-  const port = findPort();
+  const port = findPort(host);
   const p = spawn(process.execPath, [require.resolve('./worker'), port], {
     stdio: 'inherit',
     windowsHide: true,
@@ -45,10 +45,10 @@ function start() {
   started = true;
 }
 
-function findPort() {
+function findPort(host) {
   const findPortResult = spawnSync(
     process.execPath,
-    [require.resolve('./find-port')],
+    [require.resolve('./find-port'), host],
     {
       windowsHide: true,
     }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "lib/"
   ],
   "dependencies": {
-    "get-port": "^3.1.0"
+    "get-port": "^5.1.1"
   },
   "devDependencies": {
     "husky": "*",


### PR DESCRIPTION
Hi @ForbesLindesay, I'm seeing a macOS firewall popup appear and blink away quickly by calling the `init` function.

```js
const init = require('./lib');
init('');
```

This PR should contain the fix. It updates the `get-port` package (which contains a new `host` parameter) and passes `127.0.0.1` to it.

Thanks!